### PR TITLE
Update deleteNode method in BST-imp

### DIFF
--- a/Tree-DataStructure/BST-imp/main.cpp
+++ b/Tree-DataStructure/BST-imp/main.cpp
@@ -114,7 +114,7 @@ public:
                     }
                     else if(temp->right != NULL&&data<root->data)
                     {
-                      parent->right = temp->right;
+                      parent->left = temp->right;
                     }
                     else{
                       //checking if temp has no value in the right and data is greater than parent

--- a/Tree-DataStructure/BST-imp/main.cpp
+++ b/Tree-DataStructure/BST-imp/main.cpp
@@ -104,13 +104,22 @@ public:
                 else if (temp->left == NULL || temp->right == NULL)
                 {
                     cout << "We are deleting parent node which have one child" << endl;
-                    if (temp->left != NULL)
+                    if (temp->left != NULL&&data<root->data)
                     {
                         parent->left = temp->left;
                     }
-                    else
+                    else if(temp->right != NULL&&data>root->data)
                     {
                         parent->right = temp->right;
+                    }
+                    else if(temp->right != NULL&&data<root->data)
+                    {
+                      parent->right = temp->right;
+                    }
+                    else{
+                      //checking if temp has no value in the right and data is greater than parent
+                      //then the parent right value is temp's left value
+                      parent->right = temp->left; 
                     }
                     free(temp);
                     return;


### PR DESCRIPTION
There was a bug in the deleteNode method, where when we delete node 30 without Node 40, then the program shows random numbers in the tree. Whereas, the program should replace the 30 to 25. Now I hope the program was bug-free.